### PR TITLE
Fix #132. Negative years (e.g zooming out) break fetching and rendering

### DIFF
--- a/src/cache/Cache.ts
+++ b/src/cache/Cache.ts
@@ -98,6 +98,8 @@ export function getEntityKey(entity: EntityConfig) {
   }
   throw new Error(`Entity malformed:${JSON.stringify(entity)}`);
 }
+
+const MIN_SAFE_TIMESTAMP = Date.parse("0001-01-02T00:00:00.000Z");
 export default class Cache {
   ranges: Record<string, TimestampRange[]> = {};
   histories: Record<string, EntityState[]> = {};
@@ -132,6 +134,7 @@ export default class Cache {
     significant_changes_only: boolean,
     minimal_response: boolean
   ) {
+    range = range.map((n) => Math.max(MIN_SAFE_TIMESTAMP, n)); // HA API can't handle negative years
     return (this.busy = this.busy
       .catch(() => {})
       .then(async () => {

--- a/src/themed-layout.ts
+++ b/src/themed-layout.ts
@@ -14,6 +14,7 @@ const defaultLayout: Partial<Plotly.Layout> = {
   dragmode: "pan",
   xaxis: {
     autorange: false,
+    type: "date",
     // automargin: true, // it makes zooming very jumpy
   },
   yaxis: {


### PR DESCRIPTION
* Fix parsing of negative iso dates
* Default x axis type to date to avoid the axis defaulting to numbers when all traces are empty.