### PR TITLE
ci: compile the project using GitHub actions

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -1,0 +1,22 @@
+name: Build on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Upload release asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: dist/plotly-graph-card.js


### PR DESCRIPTION
With this new action the project is compiled every time a new release is published and the output file is attached to it. No need to compile manually and create a commit for it.
If you decide to use this I suggest you to delete the dist folder from the repo and add it to the `.gitignore`.

No changes for HACS, everything continue to work.