### PR TITLE
Fix right-to-left

### DIFF
--- a/src/plotly-graph-card.ts
+++ b/src/plotly-graph-card.ts
@@ -96,6 +96,7 @@ export class PlotlyGraph extends HTMLElement {
               background: transparent;
               width: 100%;
               height: calc(100% - 5px);
+              direction: ltr;
             }
             ha-card > #plotly{
               width: 100px;


### PR DESCRIPTION
Fix graph being hidden when home assistant language is right to left

Before:
![image](https://user-images.githubusercontent.com/37745463/212852330-1bbf9c8c-3023-482d-81b0-5a993fb9489d.png)


After:
![image](https://user-images.githubusercontent.com/37745463/212852181-023be5de-ea1c-403f-bf01-a52f3b7ca801.png)
