### PR TITLE
Add support for annotation and button click

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -758,6 +758,44 @@ on_dblclick: |-
   }
 ```
 
+## Annotation and button click handlers
+
+In a similar way, you can respond to clicks on annotations (requiring `captureevents: true`).
+
+```yaml
+type: custom:plotly-graph
+entities:
+  - entity: sensor.temperature1
+layout:
+  annotations:
+    - x: 1
+      xref: paper
+      "y": 1
+      yref: paper
+      showarrow: false
+      text: "📊"
+      captureevents: true
+      on_click: $ex () => { window.location="/history?entity_id=sensor.temperature1"; }
+```
+
+Or to clicks on custom update menu buttons.
+
+```yaml
+type: custom:plotly-graph
+entities:
+  - entity: sensor.temperature1
+layout:
+  updatemenus:
+    - buttons:
+        - label: History
+          method: skip
+          on_click: $ex () => { window.location="/history?entity_id=sensor.temperature1"; }
+      showactive: false
+      type: buttons
+      x: 1
+      "y": 1
+```
+
 See more in plotly's [official docs](https://plotly.com/javascript/plotlyjs-events)
 
 ## Universal functions

--- a/src/plotly-graph-card.ts
+++ b/src/plotly-graph-card.ts
@@ -54,6 +54,8 @@ export class PlotlyGraph extends HTMLElement {
     legendItemDoubleclick?: EventEmitter;
     dataClick?: EventEmitter;
     doubleclick?: EventEmitter;
+    annotationClick?: EventEmitter;
+    buttonClick?: EventEmitter;
   } = {};
 
   constructor() {
@@ -178,6 +180,15 @@ export class PlotlyGraph extends HTMLElement {
       "plotly_doubleclick",
       this.onDoubleclick
     )!;
+    this.handles.annotationClick = this.contentEl.on(
+      "plotly_clickannotation",
+      this.onAnnotationClick
+    )!;
+    this.handles.buttonClick = this.contentEl.on(
+      // @ts-ignore Not properly typed in @types/plotly.js
+      "plotly_buttonclicked",
+      this.onButtonClick
+    )!;
     this.resetButtonEl.addEventListener("click", this.exitBrowsingMode);
     this.touchController.connect();
     this.plot({ should_fetch: true });
@@ -197,6 +208,8 @@ export class PlotlyGraph extends HTMLElement {
     );
     this.handles.dataClick?.off("plotly_click", this.onDataClick);
     this.handles.doubleclick?.off("plotly_doubleclick", this.onDoubleclick);
+    this.handles.annotationClick?.off("plotly_clickannotation", this.onAnnotationClick);
+    this.handles.buttonClick?.off("plotly_buttonclicked", this.onButtonClick);
     clearTimeout(this.handles.refreshTimeout!);
     this.resetButtonEl.removeEventListener("click", this.exitBrowsingMode);
     this.touchController.disconnect();
@@ -308,6 +321,18 @@ export class PlotlyGraph extends HTMLElement {
   };
   onDoubleclick = () => {
     return this.parsed_config.on_dblclick();
+  };
+  onAnnotationClick = ({ annotation, ...rest }) => {
+    if (annotation.on_click) {
+        return annotation.on_click({ annotation, ...rest });
+    }
+    return true;
+  };
+  onButtonClick = ({ button, ...rest }) => {
+    if (button._input.on_click) {
+        return button._input.on_click({ button, ...rest });
+    }
+    return true;
   };
   onRestyle = async () => {
     // trace visibility changed, fetch missing traces


### PR DESCRIPTION
Thank you for this great card!
I missed a few (minor) features, so I prepared two pull requests. I hope you find some time to review these.

## Summary

Adds `on_click` event handlers for annotations and update menu buttons. Examples added to the readme.