### PR TITLE
Fix readme formatting of preset examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1072,9 +1072,8 @@ Below is an example YAML configuration that is split into several corresponding 
 <table>
 <tr>
 <th>YAML configuration</th>
-<th>Preset configurations</th>
 </tr>
-<tr style="vertical-align:top">
+<tr>
 <td>
 
 ```yaml
@@ -1082,7 +1081,10 @@ hours_to_show: current_day
 time_offset: -24h
 defaults:
   entity:
-    hovertemplate: "$fn ({ get }) => `%{y:,.1f} ${get('.unit_of_measurement')}<extra>${get('.name')}</extra>`"
+    hovertemplate: |
+      $fn ({ get }) => (
+        `%{y:,.1f} ${get('.unit_of_measurement')}<extra>${get('.name')}</extra>`
+      )
   xaxes:
     showspikes: true
     spikemode: across
@@ -1090,6 +1092,11 @@ defaults:
 ```
 
 </td>
+</tr>
+<tr>
+<th>Preset configurations</th>
+</tr>
+<tr>
 <td>
 
 ```js
@@ -1101,7 +1108,9 @@ window.PlotlyGraphCardPresets = {
   simpleHover: { // Start of preset with name 'simpleHover'
     defaults: {
       entity: {
-        hovertemplate: ({get}) => `%{y:,.1f} ${get(".unit_of_measurement")}<extra>${get(".name")}</extra>`,
+        hovertemplate: ({get}) => (
+          `%{y:,.1f} ${get('.unit_of_measurement')}<extra>${get('.name')}</extra>`
+        ),
       },
     },
   },


### PR DESCRIPTION
Sorry, I didn't catch the different rendering of the readme on Github (without word wrap). I believe it's in a more readable state now:

![image](https://github.com/user-attachments/assets/7b68bbdb-17e2-4a92-bcd3-1c272187036c)
