### PR TITLE
Allow filter functions to be async

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -638,6 +638,20 @@ entities:
       - map_y: parseFloat(y) * parseFloat(hass.states['sensor.cost'].state)
 ```
 
+This can also be used to fetch data by calling a HA service. As this is a call that requires a network connection, the function needs to be defined `async`:
+```yaml
+    filters:
+      - fn: |-
+          async ({xs, ys, meta, hass}) => {
+            const weather = await hass.callService("weather", "get_forecasts", {type: "hourly"}, {entity_id:"weather.home"}, true, true)
+            const home = weather.response["weather.home"].forecast
+            return {
+              xs: home.map(h => new Date(h.datetime)),
+              ys: home.map(h => h.temperature)
+            }
+          }
+```
+
 ##### Using vars
 
 Compute absolute humidity

--- a/src/parse-config/parse-config.ts
+++ b/src/parse-config/parse-config.ts
@@ -161,7 +161,7 @@ class ConfigParser {
     value = parent[key];
 
     if (path.match(/^entities\.\d+\.filters\.\d+$/)) {
-      this.evalFilter({ parent, path, key, value });
+      await this.evalFilter({ parent, path, key, value });
     }
     if (path.match(/^entities\.\d+$/)) {
       if (!this.fnParam.xs) {
@@ -330,7 +330,7 @@ class ConfigParser {
     }
     return value;
   }
-  private evalFilter(input: {
+  private async evalFilter(input: {
     parent: object;
     path: string;
     key: string;
@@ -356,7 +356,7 @@ class ConfigParser {
     }
     const filterfn = config === null ? filter() : filter(config);
     try {
-      const r = filterfn(this.fnParam);
+      const r = await filterfn(this.fnParam);
       for (const key in r) {
         this.fnParam[key] = r[key];
       }


### PR DESCRIPTION
Hi,
this is a simple PR that adds an "await" around the filter function calling.

### Motivation:
This allows especially the `fn` filter to define an `async` function.
This can be very useful, e.g. if you want to plot the result of a service call directly, without having to create intermediate template sensors just to deliver data to the frontend.
intermediate template sensors are sometimes not great when you want to display a lot of data, since the amount of bytes a state or state attributes can have is very limited (state 255 bytes AFAIK, and state attributes 16kb).
This limitation is there for a good reason: https://github.com/home-assistant/core/pull/149316#issuecomment-3141861965

Also, they fill up your recorder with information that might not be desirable to be stored long term.

With this PR, it is now possible to do this:
```yaml
    filters:
      - fn: |-
          async ({xs, ys, meta, hass}) => {
            const weather = await hass.callService("weather", "get_forecasts", {type: "hourly"}, {entity_id:"weather.home"}, true, true)
            const home = weather.response["weather.home"].forecast
            return {
              xs: home.map(h => new Date(h.datetime)),
              ys: home.map(h => h.temperature)
            }
          }
```
