### PR TITLE
Fixes duplicate hover info for `show_value`

### DIFF
--- a/src/parse-config/parse-config.ts
+++ b/src/parse-config/parse-config.ts
@@ -206,6 +206,7 @@ class ConfigParser {
             mode: "text+markers",
             showlegend: false,
             hoverinfo: "skip",
+            hovertemplate: null,
             textposition: "middle right",
             marker: {
               color: trace.line?.color,


### PR DESCRIPTION
Removes hover info for `show_value` generated markers.
This prevents duplicate hover info being shown for both the original trace and generated marker.

Related: https://github.com/dbuezas/lovelace-plotly-graph-card/issues/257